### PR TITLE
Fix for windows script location issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "webpack-dev-server": "^1.12.1"
   },
   "scripts": {
-    "build": "./node_modules/webpack/bin/webpack.js",
-    "play": "./node_modules/webpack-dev-server/bin/webpack-dev-server.js"
+    "build": "webpack",
+    "play": "webpack-dev-server"
   }
 }


### PR DESCRIPTION
Using the `node_modules` path to scripts will cause failures on some systems.  Change this to use the scripts contained in `node_modules/.bin` which is prepended to the path by npm.

WARNING: I Haven't been able to test this on linux/mac systems but npm should use the same behaviour.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/pkozlowski-opensource/ng2-webpack-play/1)

<!-- Reviewable:end -->
